### PR TITLE
Update activities

### DIFF
--- a/sunspear/clients.py
+++ b/sunspear/clients.py
@@ -53,6 +53,17 @@ class SunspearClient(object):
 
         return self._backend.create_activity(actstream_dict)
 
+    def update_activity(self, actstream_dict):
+        """
+        Updates an existing activity in the backend. If the object does not exist, it is created in the backend.
+
+        Parameters:	activity (dict) - a dict representing the activity
+        Raises:	SunspearInvalidActivityException if the activity doesn't have a valid id.
+        Returns:	a dict representing the newly stored activity
+        """
+
+        return self._backend.update_activity(actstream_dict)
+
     def create_reply(self, activity, actor, content, extra={}, **kwargs):
         """
         Creates a ``reply`` for an activity.


### PR DESCRIPTION
We need the ability to update activities. The update_activity method was not exposed. There was also an issue updating a sub activity trying to recreate the indexes that exist when the parent is not passed because we are working with an already created sub activity with its own id.

Tests:

https://github.com/7Geese/7Geese/blob/6e16bc5600411c357e0513b77802d0635dd28286/tests/apps/sgactivitystream/activities.py#L123